### PR TITLE
Update build.yml; Bump JDK to 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
       release_id: ${{ steps.release.outputs.id }}
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 19
-      uses: actions/setup-java@v3
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 20
+        java-version: 21
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
Should fix the issue mentioned in [this PR](https://github.com/servertap-io/servertap/pull/272#issuecomment-2667401941)

Looks like paper might require the newer JDK on their new API. Test run:
https://github.com/c1oneman/servertap_fix_scoreboards/actions/runs/13405005891