### PR TITLE
Add Folia compatibility

### DIFF
--- a/src/main/java/io/servertap/ServerTapMain.java
+++ b/src/main/java/io/servertap/ServerTapMain.java
@@ -7,6 +7,7 @@ import io.servertap.plugin.api.ServerTapWebserverService;
 import io.servertap.plugin.api.ServerTapWebserverServiceImpl;
 import io.servertap.utils.ConsoleListener;
 import io.servertap.utils.LagDetector;
+import io.servertap.utils.SchedulerUtils;
 import io.servertap.utils.pluginwrappers.ExternalPluginWrapperRepo;
 import io.servertap.webhooks.WebhookEventListener;
 import org.apache.logging.log4j.LogManager;
@@ -61,7 +62,7 @@ public class ServerTapMain extends JavaPlugin {
         externalPluginWrapperRepo = new ExternalPluginWrapperRepo(this, log);
 
         // Start the TPS Counter with a 100 tick Delay every 1 tick
-        Bukkit.getScheduler().runTaskTimer(this, lagDetector, 100, 1);
+        SchedulerUtils.runRepeatingTask(this, lagDetector, 100, 1);
 
         // Initialize config file + set defaults
         saveDefaultConfig();

--- a/src/main/java/io/servertap/metrics/Metrics.java
+++ b/src/main/java/io/servertap/metrics/Metrics.java
@@ -32,6 +32,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
+import io.servertap.utils.SchedulerUtils;
 
 public class Metrics {
 
@@ -87,7 +88,13 @@ public class Metrics {
                         enabled,
                         this::appendPlatformData,
                         this::appendServiceData,
-                        submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
+                        submitDataTask -> {
+                            if (SchedulerUtils.isFolia()) {
+                                Bukkit.getGlobalRegionScheduler().run(plugin, task -> submitDataTask.run());
+                            } else {
+                                Bukkit.getScheduler().runTask(plugin, submitDataTask);
+                            }
+                        },
                         plugin::isEnabled,
                         (message, error) -> this.plugin.getLogger().log(Level.WARNING, message, error),
                         (message) -> this.plugin.getLogger().log(Level.INFO, message),

--- a/src/main/java/io/servertap/utils/SchedulerUtils.java
+++ b/src/main/java/io/servertap/utils/SchedulerUtils.java
@@ -1,0 +1,58 @@
+package io.servertap.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Utility class for handling scheduler operations in a way that's compatible with both Bukkit and Folia.
+ */
+public class SchedulerUtils {
+
+    /**
+     * Checks if the server is running Folia
+     * 
+     * @return true if the server is running Folia, false otherwise
+     */
+    public static boolean isFolia() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Runs a repeating task that works on both Bukkit and Folia
+     * 
+     * @param plugin The plugin instance
+     * @param runnable The task to run
+     * @param delay The delay before first execution in ticks
+     * @param period The period between executions in ticks
+     */
+    public static void runRepeatingTask(Plugin plugin, Runnable runnable, long delay, long period) {
+        if (isFolia()) {
+            // Use Folia's global region scheduler for server-wide tasks
+            Bukkit.getGlobalRegionScheduler().runAtFixedRate(plugin, (task) -> runnable.run(), delay, period);
+        } else {
+            // Use Bukkit's scheduler for traditional servers
+            Bukkit.getScheduler().runTaskTimer(plugin, runnable, delay, period);
+        }
+    }
+
+    /**
+     * Runs a task once that works on both Bukkit and Folia
+     * 
+     * @param plugin The plugin instance
+     * @param runnable The task to run
+     */
+    public static void runTask(Plugin plugin, Runnable runnable) {
+        if (isFolia()) {
+            // Use Folia's global region scheduler for server-wide tasks
+            Bukkit.getGlobalRegionScheduler().run(plugin, (task) -> runnable.run());
+        } else {
+            // Use Bukkit's scheduler for traditional servers
+            Bukkit.getScheduler().runTask(plugin, runnable);
+        }
+    }
+}

--- a/src/main/java/io/servertap/webhooks/WebhookEventListener.java
+++ b/src/main/java/io/servertap/webhooks/WebhookEventListener.java
@@ -6,6 +6,7 @@ import io.servertap.api.v1.models.ItemStack;
 import io.servertap.api.v1.models.Player;
 import io.servertap.utils.pluginwrappers.EconomyWrapper;
 import io.servertap.utils.GsonSingleton;
+import io.servertap.utils.SchedulerUtils;
 import io.servertap.utils.pluginwrappers.ExternalPluginWrapperRepo;
 import io.servertap.webhooks.models.events.*;
 import net.md_5.bungee.api.ChatColor;
@@ -147,7 +148,12 @@ public class WebhookEventListener implements Listener {
                 continue;
             }
 
-            Bukkit.getScheduler().runTaskAsynchronously(main, () -> sendHttpRequest(eventModel, webhook));
+            // Use the AsyncScheduler for HTTP requests as they're not region-specific
+            if (SchedulerUtils.isFolia()) {
+                Bukkit.getAsyncScheduler().runNow(main, (task) -> sendHttpRequest(eventModel, webhook));
+            } else {
+                Bukkit.getScheduler().runTaskAsynchronously(main, () -> sendHttpRequest(eventModel, webhook));
+            }
         }
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ authors: [phybros, ATechAdventurer, c1oneman, Earlh21, Scarsz, au5ton, Aberdeene
 load: STARTUP
 website: https://servertap.io
 api-version: 1.16
+folia-supported: true
 softdepend:
   - Vault
   - PlaceholderAPI


### PR DESCRIPTION
Adds compatibility with Folia by introducing SchedulerUtils to abstract scheduler behavior. All sync and async tasks are now dispatched using the appropriate Folia APIs when available. Also updated plugin.yml to declare folia support. Maintains backward compatibility with Paper and Spigot.